### PR TITLE
Fix refactoring get_autotoggle in WP 2.1

### DIFF
--- a/config/sets/wp-2.1.php
+++ b/config/sets/wp-2.1.php
@@ -1,5 +1,8 @@
 <?php
 
+use Fsylum\RectorWordPress\Rules\FuncCall\ParameterAdderRector;
+use Fsylum\RectorWordPress\Rules\FuncCall\ReturnFirstArgumentRector;
+use Fsylum\RectorWordPress\ValueObject\FunctionParameterAdder;
 use Rector\Config\RectorConfig;
 use Rector\Removing\Rector\FuncCall\RemoveFuncCallArgRector;
 use Rector\Removing\Rector\FuncCall\RemoveFuncCallRector;
@@ -16,16 +19,23 @@ return static function (RectorConfig $rectorConfig): void {
         new RemoveFuncCallArg('wp_set_post_cats', 0),
     ]);
 
+    $rectorConfig->ruleWithConfiguration(ParameterAdderRector::class, [
+        new FunctionParameterAdder('get_autotoggle', 0, 0),
+    ]);
+
     $rectorConfig->ruleWithConfiguration(RemoveFuncCallRector::class, [
         'links_popup_script',
     ]);
 
     $rectorConfig->ruleWithConfiguration(RenameFunctionRector::class, [
-        'get_autotoggle'   => '__return_zero',
         'get_link'         => 'get_bookmark',
         'get_settings'     => 'get_option',
         'wp_get_post_cats' => 'wp_get_post_categories',
         'wp_set_post_cats' => 'wp_set_post_categories',
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(ReturnFirstArgumentRector::class, [
+        'get_autotoggle',
     ]);
 
     /*

--- a/tests/Rector/Sets/Level/UpToWp64/test_fixture.php.inc
+++ b/tests/Rector/Sets/Level/UpToWp64/test_fixture.php.inc
@@ -380,7 +380,7 @@ wp_create_user('foo', 'bar', 'baz');
 
 // 2.1
 get_the_author();
-$foo = __return_zero();
+$foo = 0;
 wp_get_post_categories(2);
 wp_set_post_categories(2, ['foo', 'bar']);
 get_bookmark(1);

--- a/tests/Rector/Sets/Wp21/test_fixture.php.inc
+++ b/tests/Rector/Sets/Wp21/test_fixture.php.inc
@@ -16,7 +16,7 @@ get_settings('foo');
 <?php
 
 get_the_author();
-$foo = __return_zero();
+$foo = 0;
 
 wp_get_post_categories(2);
 wp_set_post_categories(2, ['foo', 'bar']);


### PR DESCRIPTION
- Revert using `__return_zero` as it was introduced in 3.0.0